### PR TITLE
[FIX] Update playlist output type in SearchResultsMap

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- See: CONTRIBUTING.md#Pull-Requests -->
+
+### Summary
+
+<!-- Explain the context and why you're making that change.  What is the problem you're trying to solve? -->
+
+### Changes
+
+<!-- Describe the solution and changes that you have made -->
+
+### Results
+
+<!-- Describe expected new behaviour, as well as any steps on how to test / verify. -->

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,7 +269,7 @@ interface SearchResultsMap {
     album: SimplifiedAlbum
     artist: Artist
     track: Track
-    playlist: PlaylistBase
+    playlist: SimplifiedPlaylist
     show: SimplifiedShow
     episode: SimplifiedEpisode
     audiobook: SimplifiedAudiobook


### PR DESCRIPTION
### Summary

Updates output type for search when specifying 'playlist' field. Fixes #82

### Changes

Changed PlaylistBase in SearchResultsMap to SimplifiedPlaylist

### Results

Expected: Passing 'playlist' as part of the types param into search now returns a type that includes a SimplifiedPlaylist object, as shown by the docs: [https://developer.spotify.com/documentation/web-api/reference/search](https://developer.spotify.com/documentation/web-api/reference/search)